### PR TITLE
additional newline after parser.write()

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function createParser(callback) {
         if (i < lines.length) {
             var newLines = lines.slice(i);
             received = received.concat(newLines);
-            parser.write(newLines.join('\r\n'));
+            parser.write(newLines.join('\r\n') + '\r\n');
         }
     };
 


### PR DESCRIPTION
Lines are getting lost because of the lack of an additional newline with each `parser.write()`, I'm particularly noticing this with the `# ok` not getting registered and the tests not ending (in some browsers).

Thanks for the clever set of wd-tap/sacue-tap libs.
