### PR TITLE
Return raw TAP output as third argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var browser = wd.remote(),
 browser.init(function(err) {
     if (err) { return; }
 
-    wdTap(url, browser, function(err, results) {
+    wdTap(url, browser, function(err, results, rawTapOutput) {
         // results is the parsed TAP results
         if (!results.ok) {
             console.log('Tests failed');
@@ -73,5 +73,6 @@ passed to `callback`. The default timeout is 30 seconds.
 (for example if the connection to the browser was disconnected), it will be
 passed to the callback. If no error occurred, the TAP results (parsed with
 [tap-parser](https://github.com/substack/tap-parser)) will be passed to the
-callback as the second argument. Note that if a test fails, it will not be
+callback as the second argument. The raw TAP results will be passed to the 
+callback as the third argument. Note that if a test fails, it will not be
 considered an error, the results will indicate which tests passed or failed.

--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ function createParser(callback) {
 }
 
 function wdTap(url, browser, options, callback) {
-    var parser = createParser(function(data) { done(null, data); }),
+    var rawOutput = '',
+        parser = createParser(function(data) { done(null, data); }),
         finished = false,
         timeout = 30,
         cancelTimer = null,
@@ -69,6 +70,7 @@ function wdTap(url, browser, options, callback) {
                     return done(err);
                 }
 
+                rawOutput = text;
                 parser.update(text);
 
                 if (!finished) {
@@ -91,7 +93,7 @@ function wdTap(url, browser, options, callback) {
             clearTimeout(updateTimer);
         }
 
-        callback(err, data);
+        callback(err, data, rawOutput);
     }
 
     browser.get(url, function(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-tap",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Run TAP tests in the browser with WebDriver",
   "keywords": [
     "wd",

--- a/test.js
+++ b/test.js
@@ -94,8 +94,11 @@ function test() {
                 done);
         }
 
-        function done(err, results) {
-            console.log(browser.name, results.ok ? 'Passed' : 'Failed');
+        function done(err, results, rawResults) {
+            var passed = results.ok && 
+                         typeof rawResults === 'string' && 
+                         rawResults.length === 150;
+            console.log(browser.name, passed ? 'Passed' : 'Failed');
             driver.quit(function() {
                 if (!err && !results.ok) {
                     err = new Error('Tests failed');


### PR DESCRIPTION
Modified library to return raw TAP output as the third argument so that other modules that operate on raw TAP output can be used instead. (TBH, I found it ironic that tap-finished returns parsed output since the whole idea of tap is to have a well defined plaintext interface returned by a standard tap-producer)